### PR TITLE
Add Dockerfile and offscreen patch for g3n

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# ######################################################################
+# Docker container
+# ######################################################################
+FROM ubuntu:latest
+LABEL maintainer="Bernhard Reitinger <br@rexos.org>"
+
+ENV GO111MODULE=on
+
+RUN apt-get update
+ENV TZ=Europe/Vienna
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+RUN apt-get install -y xorg-dev libgl1-mesa-dev libopenal1 libopenal-dev libvorbis0a libvorbis-dev libvorbisfile3
+
+RUN apt-get install -y golang-1.14-go
+RUN apt-get install -y ca-certificates
+
+ENV PATH=$PATH:/usr/lib/go-1.14/bin
+
+WORKDIR /go/src/app
+
+COPY go.mod .
+COPY go.sum .
+
+RUN go mod download
+
+COPY . .
+
+RUN mkdir -p /go/bin
+
+RUN GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o /go/bin/web-app
+
+WORKDIR /go/bin
+
+RUN cp -r /go/src/app/templates /go/bin
+RUN cp -r /go/src/app/static /go/bin
+
+EXPOSE 8000
+
+ENTRYPOINT /go/bin/web-app

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+all: build
+
+run:
+	docker run --rm -d -p 8000:8000 local/webg3n
+
+build:
+	docker build -t local/webg3n -f Dockerfile .

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ On the other hand it shifts the bottleneck from the client's rendering capabilit
 
 Go 1.8+ is required. The engine also requires the system to have an OpenGL driver and a GCC-compatible C compiler.
 
-Requires this modified [G3N engine](https://github.com/moethu/engine) which gets installed via go modules. 
+Requires this modified [G3N engine](https://github.com/moethu/engine) which gets installed via go modules.
+
+In order to support off-screen rendering, please apply the `offscreen.patch` file to the engine.
 
 On Unix-based systems the engine depends on some C libraries that can be installed using the appropriate distribution package manager. See below for OS specific requirements.
 

--- a/offscreen.patch
+++ b/offscreen.patch
@@ -1,0 +1,12 @@
+diff --git a/window/glfw.go b/window/glfw.go
+index 298ba05..9d18b74 100644
+--- a/window/glfw.go
++++ b/window/glfw.go
+@@ -192,6 +192,7 @@ func (m *glfwManager) CreateWindow(width, height int, title string, fullscreen b
+ 	// The window is created always as not full screen because if it is
+ 	// created as full screen it not possible to revert it to windowed mode.
+ 	// At the end of this function, the window will be set to full screen if requested.
++	glfw.WindowHint(glfw.Visible, glfw.False)
+ 	win, err := glfw.CreateWindow(width, height, title, nil, nil)
+ 	if err != nil {
+ 		return nil, err


### PR DESCRIPTION
This PR contains a Dockerfile and Makefile for building a docker container. Use `make build` to build the docker container and `make run` to start it.
Make sure to have docker installed on your system.

For off-screen support, the added offscreen patch needs to be applied to the modified g3n.
NOTE: his should be handled in a better way!