### PR TITLE
Improve docker image, so it can be used for development on a mac.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update
 ENV TZ=Europe/Vienna
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN apt-get install -y xorg-dev libgl1-mesa-dev libopenal1 libopenal-dev libvorbis0a libvorbis-dev libvorbisfile3
+RUN apt-get install -y xvfb
 
 RUN apt-get install -y golang-1.14-go
 RUN apt-get install -y ca-certificates
@@ -33,7 +34,9 @@ WORKDIR /go/bin
 
 RUN cp -r /go/src/app/templates /go/bin
 RUN cp -r /go/src/app/static /go/bin
+RUN cp -r /go/src/app/models /go/bin
 
 EXPOSE 8000
 
-ENTRYPOINT /go/bin/web-app
+ENTRYPOINT ["/bin/sh", "-c", "/usr/bin/xvfb-run -s \"-screen 0 1920x1080x24\" -a $@", ""]
+CMD ["/go/bin/web-app"]


### PR DESCRIPTION
- Use xvfb for docker to enable rendering using osmesa
- The model files are moved to the directory where they are expected at runtime.